### PR TITLE
WIP browser to server tracing example

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,22 @@
+{
+  "extends": "airbnb",
+  "rules": {
+    "comma-dangle": "off",
+    "func-names": "off",
+    "no-console": "off",
+    "object-curly-spacing": [2, "never"],
+    "space-before-function-paren": [2, "never"],
+    "eqeqeq": [2, "allow-null"],
+    "no-else-return": "off",
+    "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
+    "no-underscore-dangle": "off",
+    "import/no-unresolved": [2, {
+      "ignore": ["url"] }
+    ],
+    "no-return-assign": "off",
+    "radix": ["error", "as-needed"]
+  },
+  "env": {
+    "node": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+WIP
+
+Startup zipkin on localhost, then start the node server
+```bash
+$ browserify browser.js -o public/bundle.js 
+$ node server.js 
+```
+
+Hit http://localhost:3000/ a couple times (note there's no content)
+Look at zipkin http://localhost:9411/?serviceName=browser

--- a/browser.js
+++ b/browser.js
@@ -1,23 +1,22 @@
+/* eslint-env browser */
 const {Tracer, BatchRecorder, ExplicitContext} = require('zipkin');
 const {HttpLogger} = require('zipkin-transport-http');
+const wrapFetch = require('zipkin-instrumentation-fetch');
 
 // Send spans to the origin server under the path /zipkin
 const recorder = new BatchRecorder({
   logger: new HttpLogger({
-    endpoint: location.origin + '/zipkin'
+    endpoint: `${location.origin}/zipkin`
   })
 });
 
 const ctxImpl = new ExplicitContext();
 const tracer = new Tracer({ctxImpl, recorder});
-
-const wrapFetch = require('zipkin-instrumentation-fetch');
 const zipkinFetch = wrapFetch(fetch, {tracer, serviceName: 'browser'});
 
 // wrap fetch call so that it is traced
-var result = zipkinFetch('/api')
-result.then(function(response) {
-  return response.text()
-}).catch(function(ex) {
-  console.log('failed', ex)
-})
+zipkinFetch('/api')
+  .then((response) => (response.text()))
+  .catch((ex) => {
+    console.log('failed', ex);
+  });

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,23 @@
+const {Tracer, BatchRecorder, ExplicitContext} = require('zipkin');
+const {HttpLogger} = require('zipkin-transport-http');
+
+// Send spans to the origin server under the path /zipkin
+const recorder = new BatchRecorder({
+  logger: new HttpLogger({
+    endpoint: location.origin + '/zipkin'
+  })
+});
+
+const ctxImpl = new ExplicitContext();
+const tracer = new Tracer({ctxImpl, recorder});
+
+const wrapFetch = require('zipkin-instrumentation-fetch');
+const zipkinFetch = wrapFetch(fetch, {tracer, serviceName: 'browser'});
+
+// wrap fetch call so that it is traced
+var result = zipkinFetch('/api')
+result.then(function(response) {
+  return response.text()
+}).catch(function(ex) {
+  console.log('failed', ex)
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "zipkin-js-example",
+  "version": "0.0.1",
+  "description": "Example project that shows how to use zipkin with javascript",
+  "main": "app.js",
+  "dependencies": {
+    "express": "^4.14.0",
+    "express-http-proxy": "^0.9.1",
+    "zipkin": "^0.2.6",
+    "zipkin-instrumentation-express": "^0.2.6",
+    "zipkin-instrumentation-fetch": "^0.2.6",
+    "zipkin-transport-http": "^0.2.6"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "zipkin-js-example",
   "version": "0.0.1",
   "description": "Example project that shows how to use zipkin with javascript",
-  "main": "app.js",
+  "repository": "https://github.com/openzipkin/zipkin-js",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "dependencies": {
     "express": "^4.14.0",
     "express-http-proxy": "^0.9.1",
@@ -10,5 +13,12 @@
     "zipkin-instrumentation-express": "^0.2.6",
     "zipkin-instrumentation-fetch": "^0.2.6",
     "zipkin-transport-http": "^0.2.6"
+  },
+  "devDependencies": {
+    "eslint": "^3.4.0",
+    "eslint-config-airbnb": "^10.0.1",
+    "eslint-plugin-import": "^1.14.0",
+    "eslint-plugin-jsx-a11y": "^2.2.1",
+    "eslint-plugin-react": "^6.2.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,9 +1,10 @@
 const {Tracer, BatchRecorder, ExplicitContext} = require('zipkin');
 const {HttpLogger} = require('zipkin-transport-http');
-const zipkinBaseUrl = 'http://localhost:9411'
+
+const zipkinBaseUrl = 'http://localhost:9411';
 const recorder = new BatchRecorder({
   logger: new HttpLogger({
-    endpoint: zipkinBaseUrl + '/api/v1/spans'
+    endpoint: `${zipkinBaseUrl}/api/v1/spans`
   })
 });
 const ctxImpl = new ExplicitContext();
@@ -23,23 +24,21 @@ app.use(zipkinMiddleware({
 }));
 
 // Serve the bundled browser.js
-app.get('/', function (req, res) {
+app.get('/', (req, res) => {
   res.send('<html><body><script src="/bundle.js"></script></body></html>');
 });
 
 // Mount zipkin's POST endpoint to /zipkin for browsers to use
 // In real life, you can re-use your existing auth api when proxying
 app.use('/zipkin', proxy(zipkinBaseUrl, {
-  forwardPath: function(req, res) {
-    return '/api/v1/spans'
-  }
+  forwardPath: () => ('/api/v1/spans')
 }));
 
 // Actual http call that will end up in the trace
-app.get('/api', function (req, res) {
+app.get('/api', (req, res) => {
   res.send('Hello World!');
 });
 
-app.listen(3000, function () {
+app.listen(3000, () => {
   console.log('Example app listening on port 3000!');
 });

--- a/server.js
+++ b/server.js
@@ -1,0 +1,45 @@
+const {Tracer, BatchRecorder, ExplicitContext} = require('zipkin');
+const {HttpLogger} = require('zipkin-transport-http');
+const zipkinBaseUrl = 'http://localhost:9411'
+const recorder = new BatchRecorder({
+  logger: new HttpLogger({
+    endpoint: zipkinBaseUrl + '/api/v1/spans'
+  })
+});
+const ctxImpl = new ExplicitContext();
+const tracer = new Tracer({ctxImpl, recorder});
+
+const express = require('express');
+const proxy = require('express-http-proxy');
+const zipkinMiddleware = require('zipkin-instrumentation-express').expressMiddleware;
+
+const app = express();
+app.use(express.static('public'));
+
+// Add the Zipkin middleware
+app.use(zipkinMiddleware({
+  tracer,
+  serviceName: 'server' // name of this application
+}));
+
+// Serve the bundled browser.js
+app.get('/', function (req, res) {
+  res.send('<html><body><script src="/bundle.js"></script></body></html>');
+});
+
+// Mount zipkin's POST endpoint to /zipkin for browsers to use
+// In real life, you can re-use your existing auth api when proxying
+app.use('/zipkin', proxy(zipkinBaseUrl, {
+  forwardPath: function(req, res) {
+    return '/api/v1/spans'
+  }
+}));
+
+// Actual http call that will end up in the trace
+app.get('/api', function (req, res) {
+  res.send('Hello World!');
+});
+
+app.listen(3000, function () {
+  console.log('Example app listening on port 3000!');
+});


### PR DESCRIPTION
This shows how to use the [zipkin-js](https://github.com/openzipkin/zipkin-js) library in both Node and also the browser.

It also shows how useless I am in terms of javascript. Hoping someone interested can help make this branch actually do something like we have in the [finagle example](https://github.com/openzipkin/zipkin-finagle-example)

One design point is that this proxy-mounts zipkin's http transport to the frontend server under the path "/zipkin" like below.  This means the browser doesn't need config or auth management related to zipkin. It is an emerging pattern we're toying with, and needs vetting.

``` javascript
// Mount zipkin's POST endpoint to /zipkin for browsers to use
// In real life, you can re-use your existing auth api when proxying
app.use('/zipkin', proxy(zipkinBaseUrl, {
  forwardPath: function(req, res) {
    return '/api/v1/spans'
  }
}));
```

Here's an example of a basic trace made by clicking on the useless UI I made:

<img width="809" alt="screen shot 2016-08-14 at 8 51 54 pm" src="https://cloud.githubusercontent.com/assets/64215/17649399/363b36c4-6267-11e6-8cf2-b37f31b75541.png">
