### PR TITLE
Simplify setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+bundle.js

--- a/README.md
+++ b/README.md
@@ -24,19 +24,18 @@ Next, you can view traces that went through the backend via http://localhost:941
 
 Before you start anything, you'll need to download the libraries used in this demo:
 ```bash
-$ npm update
+$ npm install
 ```
 
 Once that's done, bundle the JavaScript used by the browser:
 ```bash
-$ browserify browser.js -o bundle.js
+$ npm run browserify
 ```
 
 ## Starting the Services
-In a separate tab or window, start each of [frontend.js](./frontend.js) and [backend.js](./backend.js):
+In a separate tab or window, run `npm start`, which will start both [frontend.js](./frontend.js) and [backend.js](./backend.js):
 ```bash
-$ node frontend.js
-$ node backend.js
+$ npm start
 ```
 
 Next, run [Zipkin](http://zipkin.io/), which stores and queries traces reported by the browser and above services.
@@ -44,4 +43,10 @@ Next, run [Zipkin](http://zipkin.io/), which stores and queries traces reported 
 ```bash
 $ wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
 $ java -jar zipkin.jar
+```
+
+Or, if you're using docker:
+
+```bash
+$ docker run -d -p 9411:9411 openzipkin/zipkin
 ```

--- a/backend.js
+++ b/backend.js
@@ -1,11 +1,13 @@
+/* eslint-disable import/newline-after-import */
 // initialize tracer
-const {recorder} = require('./recorder.js');
-const {Tracer} = require('zipkin');
+const express = require('express');
 const CLSContext = require('zipkin-context-cls');
+const {Tracer} = require('zipkin');
+const {recorder} = require('./recorder');
+
 const ctxImpl = new CLSContext('zipkin');
 const tracer = new Tracer({ctxImpl, recorder});
 
-const express = require('express');
 const app = express();
 
 // instrument the server

--- a/browser.js
+++ b/browser.js
@@ -1,10 +1,12 @@
 /* eslint-env browser */
+/* eslint-disable import/newline-after-import */
 // use higher-precision time than milliseconds
 process.hrtime = require('browser-process-hrtime');
 
 // setup tracer
-const {recorder} = require('./recorder.js');
+const {recorder} = require('./recorder');
 const {Tracer, ExplicitContext} = require('zipkin');
+
 const ctxImpl = new ExplicitContext();
 const tracer = new Tracer({ctxImpl, recorder});
 
@@ -12,10 +14,11 @@ const tracer = new Tracer({ctxImpl, recorder});
 const wrapFetch = require('zipkin-instrumentation-fetch');
 const zipkinFetch = wrapFetch(fetch, {tracer, serviceName: 'browser'});
 
+const logEl = document.getElementById('log');
+const log = text => logEl.innerHTML = `${logEl.innerHTML}\n${text}`;
+
 // wrap fetch call so that it is traced
 zipkinFetch('http://localhost:8081/')
-  .then((response) => (response.text()))
-  .then((text) => (document.writeln(text)))
-  .catch((ex) => {
-    console.log('failed', ex);
-  });
+  .then(response => (response.text()))
+  .then(text => log(text))
+  .catch(err => log(`Failed:\n${err.stack}`));

--- a/frontend.js
+++ b/frontend.js
@@ -1,13 +1,15 @@
+/* eslint-disable import/newline-after-import */
 // initialize tracer
-const {recorder} = require('./recorder.js');
-const {Tracer} = require('zipkin');
+const rest = require('rest');
+const express = require('express');
 const CLSContext = require('zipkin-context-cls');
+const {Tracer} = require('zipkin');
+const {recorder} = require('./recorder');
+
 const ctxImpl = new CLSContext('zipkin');
 const tracer = new Tracer({ctxImpl, recorder});
 
-const express = require('express');
 const app = express();
-const rest = require('rest');
 
 // instrument the server
 const zipkinMiddleware = require('zipkin-instrumentation-express').expressMiddleware;
@@ -23,16 +25,17 @@ const zipkinRest = rest.wrap(restInterceptor, {tracer, serviceName: 'frontend'})
 // Allow cross-origin, traced requests. See http://enable-cors.org/server_expressjs.html
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Accept, X-B3-TraceId, X-B3-ParentSpanId, X-B3-SpanId, X-B3-Sampled');
+  res.header('Access-Control-Allow-Headers', [
+    'Origin', 'Accept', 'X-Requested-With', 'X-B3-TraceId',
+    'X-B3-ParentSpanId', 'X-B3-SpanId', 'X-B3-Sampled'
+  ].join(', '));
   next();
 });
 
 app.get('/', (req, res) => {
   zipkinRest('http://localhost:9000/api')
-    .then(
-      (response) => res.send(response.entity),
-      (response) => console.error("Error", response.status)
-    );
+    .then(response => res.send(response.entity))
+    .catch(err => console.error('Error', err.stack));
 });
 
 app.listen(8081, () => {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
   <body>
+    <pre id="log">Calling frontend service...</pre>
     <script type="text/javascript" charset="utf-8" src="./bundle.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "Example project that shows how to use zipkin with javascript",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "start": "node servers.js",
+    "browserify": "browserify browser.js -o bundle.js"
   },
   "dependencies": {
+    "browser-process-hrtime": "^0.1.2",
     "express": "^4.14.0",
     "rest": "^1.3.2",
     "zipkin": "^0.6.1",
@@ -14,14 +17,14 @@
     "zipkin-instrumentation-cujojs-rest": "^0.6.1",
     "zipkin-instrumentation-express": "^0.6.1",
     "zipkin-instrumentation-fetch": "^0.6.1",
-    "zipkin-transport-http": "^0.6.1",
-    "browser-process-hrtime": "^0.1.2"
+    "zipkin-transport-http": "^0.6.1"
   },
   "devDependencies": {
+    "browserify": "^14.1.0",
     "eslint": "^3.4.0",
-    "eslint-config-airbnb": "^10.0.1",
-    "eslint-plugin-import": "^1.14.0",
-    "eslint-plugin-jsx-a11y": "^2.2.1",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.2.0"
   }
 }

--- a/servers.js
+++ b/servers.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const childProc = require('child_process');
+
+childProc.fork(path.join(__dirname, 'frontend.js'));
+childProc.fork(path.join(__dirname, 'backend.js'));


### PR DESCRIPTION
This PR makes a few things a bit easier to set up:

* Browserify is included as a dev dependency and can be run with `npm run browserify` to generate the bundle
* Added a `servers.js` script which forks `frontend.js` and `backend.js` and added a start task for it so you can simply run `npm start` to get these up and running
* Took the liberty of replacing the `document.writeln()` call with the most basic of DOM-manipulation, since `document.write` is the scourge of the javascript world
* Upgraded eslint configs and fixed the issues it was complaining about
