### PR TITLE
Switches to Axios and adds supreme debug statements

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -50,3 +50,12 @@ Or, if you're using docker:
 ```bash
 $ docker run -d -p 9411:9411 openzipkin/zipkin
 ```
+
+## Debugging
+
+If you want to see what data is recorded and sent to Zipkin as json, start your servers differently:
+```bash
+$ DEBUG=true npm start
+```
+
+If you want to see this also in the browser's javascript console, reload the page with the query parameter `?debug`.

--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,8 @@
 # Basic example showing distributed tracing from a web browser across node.js apps
-This is an example app where a web browser and two express (node.js) services collaborate on an http request. Notably, timing of these requests are recorded into [Zipkin](https://zipkin.apache.org/), a distributed tracing system. This allows you to see the how long the whole operation took, as well how much time was spent in each service.
+This is an example app where a web browser and two express (node.js) services collaborate on an http request. Notably, timing of these requests are recorded into [Zipkin](https://zipkin.io/), a distributed tracing system. This allows you to see the how long the whole operation took, as well how much time was spent in each service.
 
 Here's an example of what it looks like
-<img width="972" alt="zipkin screen shot" src="https://user-images.githubusercontent.com/64215/58941389-40a31680-87ae-11e9-80bd-6b8d5ef222c3.png"/>
+<img width="1024" alt="zipkin screen shot" src="https://user-images.githubusercontent.com/64215/60377642-51f8df00-9a4b-11e9-88f0-a33428e6110c.png" />
 
 This example was initially shown at [DevOpsDays Singapore on Oct 8, 2016](https://speakerdeck.com/adriancole/introduction-to-distributed-tracing-and-zipkin-at-devopsdays-singapore). It was ported from similar examples, such as [Spring Boot](https://github.com/openzipkin/sleuth-webmvc-example).
 
@@ -38,10 +38,10 @@ In a separate tab or window, run `npm start`, which will start both [frontend.js
 $ npm start
 ```
 
-Next, run [Zipkin](https://zipkin.apache.org/), which stores and queries traces reported by the browser and above services.
+Next, run [Zipkin](https://zipkin.io/), which stores and queries traces reported by the browser and above services.
 
 ```bash
-$ curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s
+$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
 $ java -jar zipkin.jar
 ```
 

--- a/web/README.md
+++ b/web/README.md
@@ -52,10 +52,35 @@ $ docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
 ## Debugging
+zipkin-js bundles events together and asynchronously sends them as json to Zipkin.
 
-If you want to see what data is recorded and sent to Zipkin as json, start your servers differently:
+If you want to see which events are recorded vs the json sent to Zipkin as json, start your servers differently:
 ```bash
 $ DEBUG=true npm start
 ```
 
-If you want to see this also in the browser's javascript console, reload the page with the query parameter `?debug`.
+Here's example output:
+```
+$ DEBUG=true npm start
+
+> zipkin-js-example@0.0.1 start /Users/acole/oss/zipkin-js-example/web
+> node servers.js
+
+Backend listening on port 9000!
+Frontend listening on port 8081!
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 ServiceName("frontend")
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 Rpc("OPTIONS")
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 BinaryAnnotation(http.path="/")
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 ServerRecv()
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 LocalAddr(host="InetAddress(192.168.43.211)", port=0)
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 BinaryAnnotation(http.status_code="200")
+frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 ServerSend()
+frontend reporting: {"traceId":"a1b7b7274a26ac85","id":"a1b7b7274a26ac85","name":"options","kind":"SERVER","timestamp":1561769117353000,"duration":8233,"localEndpoint":{"serviceName":"frontend","ipv4":"192.168.43.211"},"tags":{"http.path":"/","http.status_code":"200"}}
+--snip--
+```
+
+You can also see this in the browser's javascript console, if you reload index.html with the query parameter `?debug`.
+
+Here's example output:
+
+<img width="1178" alt="browser debug" src="https://user-images.githubusercontent.com/64215/60377536-bb2c2280-9a4a-11e9-81c2-421ae2e1d125.png">

--- a/web/backend.js
+++ b/web/backend.js
@@ -3,12 +3,11 @@
 const express = require('express');
 const CLSContext = require('zipkin-context-cls');
 const {Tracer} = require('zipkin');
-const {debugRecorder} = require('./recorder');
+const {recorder} = require('./recorder');
 
 const ctxImpl = new CLSContext('zipkin');
 const localServiceName = 'backend';
-const recorder = debugRecorder(localServiceName);
-const tracer = new Tracer({ctxImpl, recorder, localServiceName});
+const tracer = new Tracer({ctxImpl, recorder: recorder(localServiceName), localServiceName});
 
 const app = express();
 

--- a/web/backend.js
+++ b/web/backend.js
@@ -3,10 +3,11 @@
 const express = require('express');
 const CLSContext = require('zipkin-context-cls');
 const {Tracer} = require('zipkin');
-const {recorder} = require('./recorder');
+const {debugRecorder} = require('./recorder');
 
 const ctxImpl = new CLSContext('zipkin');
 const localServiceName = 'backend';
+const recorder = debugRecorder(localServiceName);
 const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const app = express();

--- a/web/browser.js
+++ b/web/browser.js
@@ -4,11 +4,12 @@
 process.hrtime = require('browser-process-hrtime');
 
 // setup tracer
-const {recorder} = require('./recorder');
+const {debugRecorder} = require('./recorder');
 const {Tracer, ExplicitContext} = require('zipkin');
 
 const ctxImpl = new ExplicitContext();
 const localServiceName = 'browser';
+const recorder = debugRecorder(localServiceName);
 const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 // instrument fetch

--- a/web/browser.js
+++ b/web/browser.js
@@ -4,13 +4,12 @@
 process.hrtime = require('browser-process-hrtime');
 
 // setup tracer
-const {debugRecorder} = require('./recorder');
+const {recorder} = require('./recorder');
 const {Tracer, ExplicitContext} = require('zipkin');
 
 const ctxImpl = new ExplicitContext();
 const localServiceName = 'browser';
-const recorder = debugRecorder(localServiceName);
-const tracer = new Tracer({ctxImpl, recorder, localServiceName});
+const tracer = new Tracer({ctxImpl, recorder: recorder(localServiceName), localServiceName});
 
 // instrument fetch
 const wrapFetch = require('zipkin-instrumentation-fetch');

--- a/web/frontend.js
+++ b/web/frontend.js
@@ -1,13 +1,14 @@
 /* eslint-disable import/newline-after-import */
 // initialize tracer
-const rest = require('rest');
+const axios = require('axios');
 const express = require('express');
 const CLSContext = require('zipkin-context-cls');
 const {Tracer} = require('zipkin');
-const {recorder} = require('./recorder');
+const {debugRecorder} = require('./recorder');
 
 const ctxImpl = new CLSContext('zipkin');
 const localServiceName = 'frontend';
+const recorder = debugRecorder(localServiceName);
 const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const app = express();
@@ -17,8 +18,8 @@ const zipkinMiddleware = require('zipkin-instrumentation-express').expressMiddle
 app.use(zipkinMiddleware({tracer}));
 
 // instrument the client
-const {restInterceptor} = require('zipkin-instrumentation-cujojs-rest');
-const zipkinRest = rest.wrap(restInterceptor, {tracer});
+const {wrapAxios} = require('zipkin-instrumentation-axiosjs');
+const zipkinAxios = wrapAxios(axios, {tracer});
 
 // Allow cross-origin, traced requests. See http://enable-cors.org/server_expressjs.html
 app.use((req, res, next) => {
@@ -31,11 +32,11 @@ app.use((req, res, next) => {
 });
 
 app.get('/', (req, res) => {
-  tracer.local('pay-me', () =>
-    zipkinRest('http://localhost:9000/api')
-      .then(response => res.send(response.entity))
-      .catch(err => console.error('Error', err.stack))
-  );
+//  tracer.local('pay-me', () =>
+    zipkinAxios.get('http://localhost:9000/api')
+      .then(response => res.send(response.data))
+      .catch(err => console.error('Error', err.response ? err.response.status : err.message))
+ // );
 });
 
 app.listen(8081, () => {

--- a/web/frontend.js
+++ b/web/frontend.js
@@ -32,11 +32,11 @@ app.use((req, res, next) => {
 });
 
 app.get('/', (req, res) => {
-//  tracer.local('pay-me', () =>
+  tracer.local('pay-me', () =>
     zipkinAxios.get('http://localhost:9000/api')
       .then(response => res.send(response.data))
       .catch(err => console.error('Error', err.response ? err.response.status : err.message))
- // );
+  );
 });
 
 app.listen(8081, () => {

--- a/web/frontend.js
+++ b/web/frontend.js
@@ -4,12 +4,11 @@ const axios = require('axios');
 const express = require('express');
 const CLSContext = require('zipkin-context-cls');
 const {Tracer} = require('zipkin');
-const {debugRecorder} = require('./recorder');
+const {recorder} = require('./recorder');
 
 const ctxImpl = new CLSContext('zipkin');
 const localServiceName = 'frontend';
-const recorder = debugRecorder(localServiceName);
-const tracer = new Tracer({ctxImpl, recorder, localServiceName});
+const tracer = new Tracer({ctxImpl, recorder: recorder(localServiceName), localServiceName});
 
 const app = express();
 

--- a/web/package.json
+++ b/web/package.json
@@ -15,10 +15,10 @@
     "express": "^4.0",
     "@types/express": "^4.0.9",
     "npm": "^6.9",
-    "rest": "^2.0",
+    "axios": "^0.19.0",
     "zipkin": "^0.18",
     "zipkin-context-cls": "^0.18",
-    "zipkin-instrumentation-cujojs-rest": "^0.18",
+    "zipkin-instrumentation-axiosjs": "^0.18",
     "zipkin-instrumentation-express": "^0.18",
     "zipkin-instrumentation-fetch": "^0.18",
     "zipkin-transport-http": "^0.18"

--- a/web/recorder.js
+++ b/web/recorder.js
@@ -26,7 +26,7 @@ function debugRecorder(serviceName) {
   const logger = {
     logSpan: (span) => {
       const json = JSON_V2.encode(span);
-      console.log(`${serviceName} sending: ${json}`);
+      console.log(`${serviceName} reporting: ${json}`);
       httpLogger.logSpan(span);
     }
   };

--- a/web/recorder.js
+++ b/web/recorder.js
@@ -5,6 +5,10 @@ const {
 } = require('zipkin');
 const {HttpLogger} = require('zipkin-transport-http');
 
+const debug = 'undefined' !== typeof window
+  ? window.location.search.indexOf('debug') !== -1
+  : process.env.DEBUG;
+
 // Send spans to Zipkin asynchronously over HTTP
 const zipkinBaseUrl = 'http://localhost:9411';
 
@@ -12,6 +16,10 @@ const httpLogger = new HttpLogger({
   endpoint: `${zipkinBaseUrl}/api/v2/spans`,
   jsonEncoder: JSON_V2
 });
+
+function recorder(serviceName) {
+  return debug ? debugRecorder(serviceName) : new BatchRecorder({logger: httpLogger});
+}
 
 function debugRecorder(serviceName) {
   // This is a hack that lets you see the data sent to Zipkin!
@@ -34,4 +42,5 @@ function debugRecorder(serviceName) {
     }
   });
 }
-module.exports.debugRecorder = debugRecorder;
+
+module.exports.recorder = recorder;

--- a/web/recorder.js
+++ b/web/recorder.js
@@ -23,7 +23,7 @@ function debugRecorder(serviceName) {
     }
   };
 
-  const batchRecorder = new BatchRecorder({timeout: 500000, logger});
+  const batchRecorder = new BatchRecorder({logger});
 
   // This is a hack that lets you see which annotations become which spans
   return ({


### PR DESCRIPTION
This should help folks understand what's happening between events and
json.

Tested including the browser. It is coherent eventhough there seems to
be an instrumentation glitch somewhere.

## Debugging

zipkin-js bundles events together and asynchronously sends them as json to Zipkin.

If you want to see which events are recorded vs the json sent to Zipkin as json, start your servers differently:
```bash
$ DEBUG=true npm start
```

Here's example output:
```
$ DEBUG=true npm start

> zipkin-js-example@0.0.1 start /Users/acole/oss/zipkin-js-example/web
> node servers.js

Backend listening on port 9000!
Frontend listening on port 8081!
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 ServiceName("frontend")
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 Rpc("OPTIONS")
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 BinaryAnnotation(http.path="/")
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 ServerRecv()
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 LocalAddr(host="InetAddress(192.168.43.211)", port=0)
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 BinaryAnnotation(http.status_code="200")
frontend recording: a1b7b7274a26ac85/a1b7b7274a26ac85 ServerSend()
frontend reporting: {"traceId":"a1b7b7274a26ac85","id":"a1b7b7274a26ac85","name":"options","kind":"SERVER","timestamp":1561769117353000,"duration":8233,"localEndpoint":{"serviceName":"frontend","ipv4":"192.168.43.211"},"tags":{"http.path":"/","http.status_code":"200"}}
--snip--
```

You can also see this in the browser's javascript console, if you reload index.html with the query parameter `?debug`.

Here's example output:

<img width="1178" alt="browser debug" src="https://user-images.githubusercontent.com/64215/60377536-bb2c2280-9a4a-11e9-81c2-421ae2e1d125.png">