### PR TITLE
Fix the import of zipkin-instrumentation-axiosjs

### DIFF
--- a/web/frontend.js
+++ b/web/frontend.js
@@ -17,7 +17,7 @@ const zipkinMiddleware = require('zipkin-instrumentation-express').expressMiddle
 app.use(zipkinMiddleware({tracer}));
 
 // instrument the client
-const {wrapAxios} = require('zipkin-instrumentation-axiosjs');
+const wrapAxios = require('zipkin-instrumentation-axiosjs');
 const zipkinAxios = wrapAxios(axios, {tracer});
 
 // Allow cross-origin, traced requests. See http://enable-cors.org/server_expressjs.html


### PR DESCRIPTION
wrapAxios is being exported as a default module export:
https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin-instrumentation-axiosjs/src/index.js#L39